### PR TITLE
优化cilix_rdc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,10 @@ ipch/
 *.vspx
 *.sap
 
+# Visual Studio profiler @20220520
+*.vcxproj
+*.vcxproj.filters
+
 # Visual Studio Trace Files
 *.e2e
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,13 +89,13 @@ list(APPEND cilix_cflags ${lint-no-hides-global-msvc})
 list(APPEND cilix_cflags ${lint-no-conditional-assignment-msvc})
 list(APPEND cilix_cflags ${lint-no-unsafe-msvc})
 
-list(APPEND cilix_cflags -Wno-implicit-fallthrough)
-list(APPEND cilix_cflags -Wno-unused-result)
 
 if(WIN32)
     list(APPEND cilix_defines WIN32_LEAN_AND_MEAN _WIN32_WINNT=0x0600)
     list(APPEND cilix_libraries psapi iphlpapi userenv ws2_32)
 else()
+	list(APPEND cilix_cflags -Wno-implicit-fallthrough)
+	list(APPEND cilix_cflags -Wno-unused-result)
     list(APPEND cilix_defines _FILE_OFFSET_BITS=64 _LARGEFILE_SOURCE)
     if(NOT CMAKE_SYSTEM_NAME MATCHES "Android|OS390")
         # TODO: This should be replaced with find_package(Threads) if possible

--- a/cilix_include/cilix_sp_ddk.h
+++ b/cilix_include/cilix_sp_ddk.h
@@ -80,6 +80,9 @@ typedef int (*___dlib_func)(void* json_in, void* json_out);
 #define DLIB_FINI "Fini"
 typedef void (*___dlib_fini)(void);
 
+#define DLIB_INVOKE "Invoke"
+typedef int(*___dlib_invoke)(void* json_in, void** json_out);
+
 /*
 --------------------------------------------------------------------------------
 interfaces of sp_cp

--- a/cilix_include/cilix_sp_ddk.h
+++ b/cilix_include/cilix_sp_ddk.h
@@ -372,12 +372,15 @@ typedef struct sp_cp_json_s {
 } sp_cp_json_t;
 
 struct sp_sapp_cp_s {
+	void* def;
 };
 
 struct sp_spip_cp_s {
+	void* def;
 };
 
 struct sp_dlib_cp_s {
+	void* def;
 };
 
 #define SP_CP_FIELDS                \

--- a/cilix_include/cilix_sp_ddk.h
+++ b/cilix_include/cilix_sp_ddk.h
@@ -81,7 +81,7 @@ typedef int (*___dlib_func)(void* json_in, void* json_out);
 typedef void (*___dlib_fini)(void);
 
 #define DLIB_INVOKE "Invoke"
-typedef int(*___dlib_invoke)(void* json_in, void** json_out);
+typedef int(*___dlib_invoke)(char* func, void* json_in, void** json_out);
 
 /*
 --------------------------------------------------------------------------------

--- a/cilix_include/cilix_sp_ddk.h
+++ b/cilix_include/cilix_sp_ddk.h
@@ -374,6 +374,19 @@ typedef struct sp_cp_json_s {
     sp_cp_json_print_free print_free;
 } sp_cp_json_t;
 
+
+typedef int  (*sp_cp_base64_ensize)(int);
+typedef int (*sp_cp_base64_encode)(char* SourceData, int SourceLen, char* Base64);
+typedef int (*sp_cp_base64_desize)(int);
+typedef int (*sp_cp_base64_decode)(char* Base64, char* DeData, int *DeDataLen);
+
+typedef struct sp_cp_base64_s{
+    sp_cp_base64_ensize base64_ensize;
+    sp_cp_base64_encode base64_encode;  
+    sp_cp_base64_desize base64_desize;
+    sp_cp_base64_decode base64_decode;
+}sp_cp_base64_t;
+
 struct sp_sapp_cp_s {
 	void* def;
 };
@@ -407,6 +420,7 @@ struct sp_dlib_cp_s {
     sp_cp_thread_t* thread;         \
     sp_cp_toml_t* toml;             \
     sp_cp_json_t* json;             \
+    sp_cp_base64_t* base64;  \
 
 struct sp_cp_s {
     SP_CP_FIELDS

--- a/cilix_os_config/cilix_os_config.h
+++ b/cilix_os_config/cilix_os_config.h
@@ -5,12 +5,13 @@
 
 /***************************************************/
 
-#ifdef _CILIX_OS_WINDOWS
+#ifdef _CILIX_OS_Windows
 
 //***** slash
 #define CILIX_PATH_SLASH '\\'
 
 //***** socket
+#define CILIX_SOCKET_ADDR_H <winsock2.h>
 
 //***** string
 #define CILIX_STRING_H <string.h>

--- a/cilix_rdc/cilix_rdc_task.c
+++ b/cilix_rdc/cilix_rdc_task.c
@@ -55,8 +55,8 @@ void rdc_task_q_get_cb(cilix_task_t* task, void* udata, void* w, cilix_task_q_do
 
     if (q->type == RDC_TASK_Q_TYPE_REQ) {
         // call : func,in,out,ret
-        DLIB_CALL(dlib_func, q->func) {
-            q->ret = df(q->in, q->out);
+		DLIB_CALL(dlib_invoke, DLIB_INVOKE) {
+			q->ret = df(q->func, q->in, &q->out);
         } else { q->ret = SP_RET_ERR_DLIB_FUNC_NOT_EXIST; } }
 
         // print : out

--- a/cilix_rdc/cilix_rdc_task.c
+++ b/cilix_rdc/cilix_rdc_task.c
@@ -56,7 +56,7 @@ void rdc_task_q_get_cb(cilix_task_t* task, void* udata, void* w, cilix_task_q_do
     if (q->type == RDC_TASK_Q_TYPE_REQ) {
         // call : func,in,out,ret
 		DLIB_CALL(dlib_invoke, DLIB_INVOKE) {
-			q->ret = df(q->func, q->in, &q->out);
+			q->ret = df(q->func, q->in, q->out);
         } else { q->ret = SP_RET_ERR_DLIB_FUNC_NOT_EXIST; } }
 
         // print : out

--- a/cilix_sp/cilix_sp_cps.c
+++ b/cilix_sp/cilix_sp_cps.c
@@ -162,6 +162,13 @@ void sp_cps_init(sp_cps_t* cps) {
         cps->json->print_free = cilix_json_print_free;
     }
 
+    cps->base64 = &cps->base64__t;{
+        cps->base64->base64_ensize = cilix_base64_ensize;
+        cps->base64->base64_encode = cilix_base64_encode;
+        cps->base64->base64_desize  = cilix_base64_desize;
+        cps->base64->base64_decode = cilix_base64_decode;
+    }
+
 }
 
 sp_cp_t* sp_cp_create(void) {

--- a/cilix_sp_include/cilix_sp_cps.h
+++ b/cilix_sp_include/cilix_sp_cps.h
@@ -17,6 +17,7 @@
 #include "cilix_thread.h"
 #include "cilix_toml.h"
 #include "cilix_json.h"
+#include "cilix_base64.h"
 
 typedef struct sp_cps_s {
     SP_CP_FIELDS
@@ -39,6 +40,7 @@ typedef struct sp_cps_s {
     sp_cp_thread_t thread__t;
     sp_cp_toml_t toml__t;
     sp_cp_json_t json__t;
+    sp_cp_base64_t base64__t;
 } sp_cps_t;
 
 void sp_cps_init(sp_cps_t* cps);

--- a/cilix_test/cilix_test.c
+++ b/cilix_test/cilix_test.c
@@ -12,6 +12,7 @@ void cilix_test_signal(void);
 void cilix_test_sys(void);
 void cilix_test_base64(void);
 void cilix_test_timeout(void);
+void cilix_test_json();
 
 #define _ARGIS(s) if (argc > 2 && CILIX_STRICMP(argv[2],s)==0)
 #define _ARGPARA(i) (argc > (3+i) ? argv[3+i] : "")

--- a/cilix_test/cilix_test.c
+++ b/cilix_test/cilix_test.c
@@ -41,7 +41,9 @@ int cilix_test_x(int argc, char **argv)
     _ARGIS("-timeout") {
         cilix_test_timeout();
     }
-
+	_ARGIS("-json") {
+		cilix_test_json();
+	}
     return 0;  
 }
 

--- a/cilix_test/cilix_test.c
+++ b/cilix_test/cilix_test.c
@@ -12,7 +12,7 @@ void cilix_test_signal(void);
 void cilix_test_sys(void);
 void cilix_test_base64(void);
 void cilix_test_timeout(void);
-void cilix_test_json();
+void cilix_test_json(void);
 
 #define _ARGIS(s) if (argc > 2 && CILIX_STRICMP(argv[2],s)==0)
 #define _ARGPARA(i) (argc > (3+i) ? argv[3+i] : "")

--- a/cilix_test/cilix_test_base64.c
+++ b/cilix_test/cilix_test_base64.c
@@ -199,7 +199,7 @@ int test_b64_decodef(void) {
 		return 0;
 	
 	int c, l=0;
-	char out[j+1];
+	char* out = (char*)malloc(j + 1);
 	while(c!=EOF) {
 		c=fgetc(pFile);
 		if (c==EOF)
@@ -210,9 +210,11 @@ int test_b64_decodef(void) {
 	remove("B64_TEST02B.tmp");
 	printf("\tComparing \"%s\" to \"",HEXSTR_B); hexprint(out,j); printf("\" : ");
 	char r_b[] = HEXNUM_B;
-	if (compare(r_b,out,j))
+	if (compare(r_b, out, j)) {
+		free(out);
 		return 1;
-	
+
+	}free(out);
 	return 0;
 }
 

--- a/cilix_test/cilix_test_base64.c
+++ b/cilix_test/cilix_test_base64.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "base64.h"
+#include "cilix_base64.h"
 
 //Test values
 ///////////////////////////////////////////////////////////////
@@ -28,6 +29,10 @@
 #define STATUS(x)  score(x)
 #define PERCENT(a,b)  ((float)((float)a/(float)b)*100)
 
+int test_cilix_b64_encode(void);
+int test_cilix_b64_decode(void);
+
+
 int test_b64_encode(void);
 int test_b64_decode(void);
 int test_b64_encodef(void);
@@ -45,6 +50,13 @@ int testScore = 0;
 int testTotal = 0;
 
 void cilix_test_base64(void) {
+
+	test_cilix_b64_decode();
+
+	test_cilix_b64_encode();
+
+
+	return ;
 	
 	puts("\nbase64.c [Test Data]");
 	puts("------------------------------------");
@@ -67,6 +79,39 @@ void cilix_test_base64(void) {
 	puts("------------------------------------");
 	printf("\n[END] Test score: %g%% (%d/%d)\n",PERCENT(testScore,testTotal),testScore,testTotal);
 
+}
+int test_cilix_b64_encode(void){
+
+	unsigned char test_a[] = HEXNUM_A;
+	unsigned char test_b[] = HEXNUM_B;
+	unsigned char test_c[] = HEXNUM_C;
+
+	unsigned int size_a = NELEMS(test_a);
+	unsigned int size_b = NELEMS(test_b);
+	unsigned int size_c = NELEMS(test_c);
+
+	int out_size_a = cilix_base64_ensize(size_a) + 1;
+	int out_size_b = cilix_base64_ensize(size_b) + 1;
+	int out_size_c = cilix_base64_ensize(size_c) + 1;
+
+	char* Base64_a = malloc(sizeof(char*)*out_size_a);
+	char* Base64_b = malloc(sizeof(char*)*out_size_b);
+	char* Base64_c = malloc(sizeof(char*)*out_size_c);
+	
+	cilix_base64_encode(test_a,size_a,Base64_a);
+	cilix_base64_encode(test_b,size_b,Base64_b);
+	cilix_base64_encode(test_c,size_c,Base64_c);
+
+
+	printf("\t%s\t%s\n",STATUS(strcmp((char*)Base64_a,STRING_A)==0),Base64_a);
+	printf("\t%s\t%s\n",STATUS(strcmp((char*)Base64_b,STRING_B)==0),Base64_b);
+	printf("\t%s\t%s\n",STATUS(strcmp((char*)Base64_c,STRING_C)==0),Base64_c);
+
+	free(Base64_a);
+	free(Base64_b);
+	free(Base64_c);
+	
+	return 0;
 }
 
 int test_b64_encode(void) {
@@ -102,6 +147,43 @@ int test_b64_encode(void) {
 	return 0;
 }
 
+int test_cilix_b64_decode(void){
+
+	unsigned char test_a[] = STRING_A;
+	unsigned char test_b[] = STRING_B;
+	unsigned char test_c[] = STRING_C;
+
+	unsigned int len_a = strlen((char*)test_a);
+	unsigned int len_b = strlen((char*)test_b);
+	unsigned int len_c = strlen((char*)test_c);
+
+	int out_size_a = cilix_base64_desize(len_a);
+	int out_size_b = cilix_base64_desize(len_b);
+	int out_size_c = cilix_base64_desize(len_c);
+
+
+	unsigned char *out_a = malloc( (sizeof(char) * out_size_a) +1);
+	unsigned char *out_b = malloc( (sizeof(char) * out_size_b) +1);
+	unsigned char *out_c = malloc( (sizeof(char) * out_size_c) +1);
+
+	 cilix_base64_decode(test_a,out_a,&out_size_a);
+	 cilix_base64_decode(test_b,out_b,&out_size_b);
+	 cilix_base64_decode(test_c,out_c,&out_size_c);
+	
+	char r_a[] = HEXNUM_A;
+	char r_b[] = HEXNUM_B;
+	char r_c[] = HEXNUM_C;
+	
+	printf("\t%s\t",STATUS(compare(r_a,(char*)out_a,NELEMS(r_a)))); hexputs((char*)out_a,out_size_a);
+	printf("\t%s\t",STATUS(compare(r_b,(char*)out_b,NELEMS(r_b)))); hexputs((char*)out_b,out_size_b);
+	printf("\t%s\t",STATUS(compare(r_c,(char*)out_c,NELEMS(r_c)))); hexputs((char*)out_c,out_size_c);
+	
+	free(out_a);
+	free(out_b);
+	free(out_c);
+	
+	return 0;
+}
 int test_b64_decode(void) {
 	
 	unsigned char test_a[] = STRING_A;

--- a/cilix_test/cilix_test_json.c
+++ b/cilix_test/cilix_test_json.c
@@ -6,7 +6,26 @@
 
 void cilix_test_json(void){
     void* mSet =  cilix_json_init("",0);
-    void* mJSChild = cilix_json_add_obj(mSet,"LFSReadRaw");
+	
+	cilix_json_add_str(mSet, "test1", NULL);
+	cilix_json_add_str(mSet, NULL, NULL);
+	cilix_json_add_str(mSet, NULL, "adf");
+	cilix_json_add_str(mSet, "asldf", "adf");
+
+	void* mJSChild = cilix_json_add_arr(mSet,"PARA");
+
+	void* mJSChild_1 = cilix_json_add_arr(mJSChild, NULL);
+	cilix_json_add_str(mJSChild_1, NULL, "TRACK2:MII = 59");
+	cilix_json_add_str(mJSChild_1,NULL , "COUNTRY = 280");
+	cilix_json_add_str(mJSChild_1, NULL, "ISSUERID = 50050500");
+	cilix_json_add_str(mJSChild_1, NULL, "LUHNT3 = 1");
+
+	void* mJSChild_2 = cilix_json_add_arr(mJSChild, "");
+	cilix_json_add_str(mJSChild_2, "", "TRACK3:MII = 30");
+	cilix_json_add_str(mJSChild_2, "", "COUNTRY = 281");
+	cilix_json_add_str(mJSChild_2, "", "ISSUERID = 51050500");
+	cilix_json_add_str(mJSChild_2, "", "LUHNT3 = 2");
+	/* void* mJSChild = cilix_json_add_obj(mSet,"LFSReadRaw");
     cilix_json_add_int(mJSChild,"Len",10);
     cilix_json_add_str(mJSChild,"Data","123456789");
    
@@ -17,18 +36,32 @@ void cilix_test_json(void){
    cilix_json_add_arr_int(mJSSit1,"b",2);
    cilix_json_add_arr_double(mJSSit1,"c",2.11);
 
-     void* mJSSit2 = cilix_json_add_arr_obj(mJSChild,"sites");
-    cilix_json_add_arr_str(mJSSit2,"a","234");
+   void* mJSSit2 = cilix_json_add_arr_obj(mJSChild,"sites");
+   cilix_json_add_arr_str(mJSSit2,"a","234");
    cilix_json_add_arr_int(mJSSit2,"b",2);
-   cilix_json_add_arr_double(mJSSit2,"c",2.11);
-
+   cilix_json_add_arr_double(mJSSit2,"c",2.11);*/
 
     char * data = cilix_json_print(mSet);
     printf(">>> data:\n%s\n<<<", data);
-
+	
     void* mGet = cilix_json_init(data,strlen(data));
+	char* test1 = cilix_json_get_str(mSet, "test1");
+	printf(">>> test1:\n%d\n<<<", strlen(test1));
 
-    void* mJSOut= cilix_json_get_obj(mGet,"LFSReadRaw");
+	void* mJSOut = cilix_json_get_obj(mGet, "PARA");
+	int iSize = cilix_json_get_arr_size(mJSOut);
+	printf("PARA Size:%d\n", iSize);
+	for (int i = 0; i < iSize; i++) {
+		void* mJSOut1 = cilix_json_get_arr_obj(mJSOut, i);
+		int iSize_ = cilix_json_get_arr_size(mJSOut1);
+		printf("%d Size:%d\n",i, iSize_);
+		for (int j = 0; j < iSize_; j++) {
+			printf("i = %d,j = %d data:%s\n", i,j,cilix_json_get_arr_str(mJSOut1, j));
+		}
+	}
+	
+
+    /*void* mJSOut= cilix_json_get_obj(mGet,"LFSReadRaw");
     
     printf("Len:%d\n",cilix_json_get_int(mJSOut,"Len"));
     printf("Data:%s\n",cilix_json_get_str(mJSOut,"Data"));
@@ -46,7 +79,7 @@ void cilix_test_json(void){
     void* mJSOut2  = cilix_json_get_arr_obj(mJSArr,1);
     printf("a:%s\n",cilix_json_get_str(mJSOut2,"a"));
     printf("b:%d\n",cilix_json_get_int(mJSOut2,"b"));
-     printf("c:%.2f\n",cilix_json_get_double(mJSOut2,"c"));
+     printf("c:%.2f\n",cilix_json_get_double(mJSOut2,"c*/
 
   return ;
 }

--- a/cilix_test/cilix_test_json.c
+++ b/cilix_test/cilix_test_json.c
@@ -1,3 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "cilix_json.h"
 
 void cilix_test_json(void){

--- a/cilix_test/cilix_test_json.c
+++ b/cilix_test/cilix_test_json.c
@@ -1,0 +1,48 @@
+#include "cilix_json.h"
+
+void cilix_test_json(void){
+    void* mSet =  cilix_json_init("",0);
+    void* mJSChild = cilix_json_add_obj(mSet,"LFSReadRaw");
+    cilix_json_add_int(mJSChild,"Len",10);
+    cilix_json_add_str(mJSChild,"Data","123456789");
+   
+    cilix_json_add_arr(mJSChild,"sites");
+
+   void* mJSSit1= cilix_json_add_arr_obj(mJSChild,"sites");
+   cilix_json_add_arr_str(mJSSit1,"a","234");
+   cilix_json_add_arr_int(mJSSit1,"b",2);
+   cilix_json_add_arr_double(mJSSit1,"c",2.11);
+
+     void* mJSSit2 = cilix_json_add_arr_obj(mJSChild,"sites");
+    cilix_json_add_arr_str(mJSSit2,"a","234");
+   cilix_json_add_arr_int(mJSSit2,"b",2);
+   cilix_json_add_arr_double(mJSSit2,"c",2.11);
+
+
+    char * data = cilix_json_print(mSet);
+    printf(">>> data:\n%s\n<<<", data);
+
+    void* mGet = cilix_json_init(data,strlen(data));
+
+    void* mJSOut= cilix_json_get_obj(mGet,"LFSReadRaw");
+    
+    printf("Len:%d\n",cilix_json_get_int(mJSOut,"Len"));
+    printf("Data:%s\n",cilix_json_get_str(mJSOut,"Data"));
+    printf("Data:%s\n",cilix_json_get_str(mJSOut,"Data"));
+
+    void* mJSArr = cilix_json_get_obj(mJSOut,"sites");
+    
+    printf("ArrSize:%d\n",cilix_json_get_arr_size(mJSArr));
+
+    void* mJSOut1  = cilix_json_get_arr_obj(mJSArr,0);
+    printf("a:%s\n",cilix_json_get_str(mJSOut1,"a"));
+    printf("b:%d\n",cilix_json_get_int(mJSOut1,"b"));
+     printf("c:%.2f\n",cilix_json_get_double(mJSOut1,"c"));
+
+    void* mJSOut2  = cilix_json_get_arr_obj(mJSArr,1);
+    printf("a:%s\n",cilix_json_get_str(mJSOut2,"a"));
+    printf("b:%d\n",cilix_json_get_int(mJSOut2,"b"));
+     printf("c:%.2f\n",cilix_json_get_double(mJSOut2,"c"));
+
+
+}

--- a/cilix_test/cilix_test_json.c
+++ b/cilix_test/cilix_test_json.c
@@ -48,5 +48,5 @@ void cilix_test_json(void){
     printf("b:%d\n",cilix_json_get_int(mJSOut2,"b"));
      printf("c:%.2f\n",cilix_json_get_double(mJSOut2,"c"));
 
-
+  return ;
 }

--- a/cilix_uv/cilix_base64.c
+++ b/cilix_uv/cilix_base64.c
@@ -1,0 +1,55 @@
+#include "cilix_base64.h"
+
+int cilix_base64_ensize(int InSize){
+    return b64e_size(InSize);
+}
+
+int cilix_base64_encode(char* SourceData, int SourceLen, char* Base64){
+
+    if((SourceData==0)||(Base64 == 0)||(SourceLen<=0)){
+        return -1;
+    }
+
+    int out_size = b64e_size(SourceLen)+1;
+    
+    unsigned char *out_data = malloc( (sizeof(char) * out_size) );
+
+    memset(out_data,0,out_size);
+
+    out_size = b64_encode(SourceData,SourceLen,out_data);
+    
+    memcpy(Base64,out_data,out_size);
+
+    free(out_data);
+
+    return out_size;
+}
+
+int cilix_base64_desize(int InSize){
+    return b64d_size(InSize);
+}
+
+int cilix_base64_decode(char* Base64, char* DeData, int *DeDataLen){
+
+     if((Base64==0)||(DeData == 0)||(DeDataLen ==0)){
+        return -1;
+    }
+
+    unsigned int len = strlen((char*)Base64);
+
+    int out_size = b64d_size(len) +1;
+
+    unsigned char *out = malloc( sizeof(char) * out_size);
+   
+    memset(out,0,out_size);
+
+    out_size = b64_decode(Base64,len,out);
+
+    memcpy(DeData,out,out_size);
+    
+    *DeDataLen =     out_size;
+    
+    free(out);
+
+    return out_size;
+}

--- a/cilix_uv/cilix_base64.h
+++ b/cilix_uv/cilix_base64.h
@@ -1,0 +1,23 @@
+#ifndef __CILIX_BASE64_H__
+#define __CILIX_BASE64_H__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "base64.h"
+
+// *** public - start ***
+
+int cilix_base64_ensize(int);
+
+int cilix_base64_encode(char* SourceData, int SourceLen, char* Base64);
+
+int cilix_base64_desize(int);
+
+int cilix_base64_decode(char* Base64, char* DeData, int *DeDataLen);
+
+
+// *** public - end ***
+
+#endif  // #__CILIX_BASE64_H__

--- a/cilix_uv/cilix_json.c
+++ b/cilix_uv/cilix_json.c
@@ -8,95 +8,184 @@
 
 #include "cilix_json.h"
 
+#define ISNULLOBJ(obj)if(!obj){return 0;}
+#define	ISNULLPTR(obj,name) if (!obj) {	return 0;}else if (obj && !name) {return 0;}
+
 void* cilix_json_init(char* str, long len) {
-    return 0;
+	cJSON *cJS = 0;
+	if (str && (len > 0)) {
+		cJS = cJSON_ParseWithLength(str, len);
+	}
+	else {
+		cJS = cJSON_CreateObject();
+	}return (void*)cJS;
 }
 
 void cilix_json_destroy(void* obj) {
-
+	if (obj) {
+		cJSON_Delete((cJSON*)obj);
+	}
 }
 
 void*  cilix_json_get_obj(void* obj, char* name) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		return (void*)cJSON_GetObjectItem((cJSON*)obj, name);
 }
 
 char*  cilix_json_get_str(void* obj, char* name) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		return  cJSON_GetObjectItem((cJSON*)obj, name)->valuestring;
 }
 
 int    cilix_json_get_int(void* obj, char* name) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		return  cJSON_GetObjectItem((cJSON*)obj, name)->valueint;
 }
 
 double cilix_json_get_double(void* obj, char* name) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		return  cJSON_GetObjectItem((cJSON*)obj, name)->valuedouble;
 }
 
 void*  cilix_json_get_arr(void* obj, char* name) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		return (void*)cJSON_GetObjectItem(obj, name);
 }
 
 int    cilix_json_get_arr_size(void* obj) {
-    return 0;
+
+	ISNULLOBJ(obj)
+
+		return cJSON_GetArraySize((cJSON*)obj);
 }
 
 void*  cilix_json_get_arr_obj(void* obj, int idx) {
-    return 0;
+
+	ISNULLOBJ(obj)
+
+		return (void*)cJSON_GetArrayItem((cJSON*)obj, idx);
 }
 
 char*  cilix_json_get_arr_str(void* obj, int idx) {
-    return 0;
+
+	ISNULLOBJ(obj)
+
+		return 0;
 }
 
 int    cilix_json_get_arr_int(void* obj, int idx) {
-    return 0;
+
+	ISNULLOBJ(obj)
+
+		return 0;
 }
 
 double cilix_json_get_arr_double(void* obj, int idx) {
-    return 0;
+
+	ISNULLOBJ(obj)
+
+		return 0;
 }
 
 
 void* cilix_json_add_obj(void* obj, char* name) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		cJSON* cJSItem = cJSON_CreateObject();
+
+	cJSON_bool bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSItem);
+	if (!bRet) {
+		cJSON_Delete(cJSItem);
+		return 0;
+	}return (void*)cJSItem;
 }
 
 void* cilix_json_add_str(void* obj, char* name, char* val) {
-    return 0;
+	ISNULLPTR(obj, name)
+
+		cJSON_bool bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateString(val));
+	if (!bRet) {
+		return 0;
+	}return obj;
 }
 
 void* cilix_json_add_int(void* obj, char* name, int val) {
-    return 0;
+	ISNULLPTR(obj, name)
+
+		cJSON_bool bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateNumber((int)val));
+	if (!bRet) {
+		return 0;
+	}return obj;
 }
 
 void* cilix_json_add_double(void* obj, char* name, double val) {
-    return 0;
+	ISNULLPTR(obj, name)
+
+		cJSON_bool bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateNumber(val));
+	if (!bRet) {
+		return 0;
+	}return obj;
 }
 
 void* cilix_json_add_arr(void* obj, char* name) {
-    return 0;
+	ISNULLPTR(obj, name)
+
+		cJSON* cJSArray = cJSON_AddArrayToObject((cJSON*)obj, name);
+	return (void*)cJSArray;
 }
 
 void* cilix_json_add_arr_obj(void* obj, char* name) {
-    return 0;
+	ISNULLPTR(obj, name)
+
+		cJSON* cJSItem = cJSON_CreateObject();
+	cJSON_AddItemToArray(cJSON_GetObjectItem(obj, name), cJSItem);
+
+	return (void*)cJSItem;
 }
 
 void* cilix_json_add_arr_str(void* obj, char* name, char* val) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateString(val));
+	return obj;
 }
 
 void* cilix_json_add_arr_int(void* obj, char* name, int val) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateNumber((double)val));
+	return 0;
 }
 
 void* cilix_json_add_arr_double(void* obj, char* name, double val) {
-    return 0;
+
+	ISNULLPTR(obj, name)
+
+		cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateNumber(val));
+	return 0;
 }
 
 char* cilix_json_print(void* obj) {
-    return 0;
+	if (!obj) {
+		return 0;
+	}return  cJSON_Print(obj);
 }
 
 void cilix_json_print_free(char* text) {
-
+	if (text) {
+		free(text);
+	}
 }

--- a/cilix_uv/cilix_json.c
+++ b/cilix_uv/cilix_json.c
@@ -79,28 +79,26 @@ void*  cilix_json_get_arr_obj(void* obj, int idx) {
 char*  cilix_json_get_arr_str(void* obj, int idx) {
 
 	ISNULLOBJ(obj)
-
-		return 0;
+	
+	return cJSON_GetArrayItem((cJSON*)obj, idx)->valuestring;
 }
 
 int    cilix_json_get_arr_int(void* obj, int idx) {
 
 	ISNULLOBJ(obj)
 
-		return 0;
+		return cJSON_GetArrayItem((cJSON*)obj, idx)->valueint;
 }
 
 double cilix_json_get_arr_double(void* obj, int idx) {
 
 	ISNULLOBJ(obj)
 
-		return 0;
+	return cJSON_GetArrayItem((cJSON*)obj, idx)->valuedouble;
 }
 
 
 void* cilix_json_add_obj(void* obj, char* name) {
-
-	ISNULLPTR(obj, name)
 
 		cJSON* cJSItem = cJSON_CreateObject();
 
@@ -112,16 +110,22 @@ void* cilix_json_add_obj(void* obj, char* name) {
 }
 
 void* cilix_json_add_str(void* obj, char* name, char* val) {
-	ISNULLPTR(obj, name)
+	if (!obj) { return 0; }
 
-		cJSON_bool bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateString(val));
+	cJSON_bool bRet;
+	
+	if(name==NULL && val == NULL) bRet = cJSON_AddItemToObject((cJSON*)obj, "", cJSON_CreateString(""));
+	else if(name == NULL && val != NULL)bRet = cJSON_AddItemToObject((cJSON*)obj, "", cJSON_CreateString(val));
+	else if(name != NULL && val == NULL)bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateString(""));
+	else bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateString(val));
+
 	if (!bRet) {
 		return 0;
 	}return obj;
 }
 
 void* cilix_json_add_int(void* obj, char* name, int val) {
-	ISNULLPTR(obj, name)
+	if (!obj) { return 0; }
 
 		cJSON_bool bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateNumber((int)val));
 	if (!bRet) {
@@ -130,7 +134,7 @@ void* cilix_json_add_int(void* obj, char* name, int val) {
 }
 
 void* cilix_json_add_double(void* obj, char* name, double val) {
-	ISNULLPTR(obj, name)
+	if (!obj) { return 0; }
 
 		cJSON_bool bRet = cJSON_AddItemToObject((cJSON*)obj, name, cJSON_CreateNumber(val));
 	if (!bRet) {
@@ -139,9 +143,10 @@ void* cilix_json_add_double(void* obj, char* name, double val) {
 }
 
 void* cilix_json_add_arr(void* obj, char* name) {
-	ISNULLPTR(obj, name)
-
-		cJSON* cJSArray = cJSON_AddArrayToObject((cJSON*)obj, name);
+	if (!obj) { return 0; }
+	cJSON* cJSArray;
+	if(!name)cJSArray = cJSON_AddArrayToObject((cJSON*)obj, "");
+	else cJSArray = cJSON_AddArrayToObject((cJSON*)obj, name);
 	return (void*)cJSArray;
 }
 

--- a/claux/libuv1.38.1/include/uv.h
+++ b/claux/libuv1.38.1/include/uv.h
@@ -66,6 +66,14 @@ extern "C" {
 # include "uv/unix.h"
 #endif
 
+#if defined(_WIN32)
+#undef	SIGUSR1
+#define	SIGUSR1	10
+#undef	SIGUSR2
+#define	SIGUSR2	12	
+#else
+#endif
+
 /* Expand this list if necessary. */
 #define UV_ERRNO_MAP(XX)                                                      \
   XX(E2BIG, "argument list too long")                                         \


### PR DESCRIPTION
1.  .gitignore 过滤项目文件；
2. 增加 win32 下 SIGUSR1 SIGUSR2 宏定义；
3. _CILIX_OS_WINSOWS 更新为 _CILIX_OS_Windows，win下增加 winsock2.h；
4. 优化支持多平台编译的兼容问题； 
5. 实现cilix_json.c、json测试代码实现；
6. 原来对drv的多接口调用，改造为Invoke一个接口通过入参传入调用的方法名。